### PR TITLE
add graalvm configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,10 @@
   <url>http://maven.apache.org</url>
 
   <properties>
+   <native.maven.plugin.version>0.9.12</native.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <imageName>bamscanner</imageName>
+     <mainClass>progistar.scan.run.Scan</mainClass>
   </properties>
 
   <dependencies>
@@ -41,4 +44,51 @@
 	  <version>0.6.3</version>
 	</dependency>
   </dependencies>
+
+
+  <profiles>
+     <profile>
+         <id>native</id>
+         <build>
+             <plugins>
+                 <plugin>
+                     <groupId>org.graalvm.buildtools</groupId>
+                     <artifactId>native-maven-plugin</artifactId>
+                     <version>${native.maven.plugin.version}</version>
+                     <extensions>true</extensions>
+                     <executions>
+                         <execution>
+                             <id>build-native</id>
+                             <goals>
+                                 <goal>build</goal>
+                             </goals>
+                             <phase>package</phase>
+                         </execution>
+                         <execution>
+                             <id>test-native</id>
+                             <goals>
+                                 <goal>test</goal>
+                             </goals>
+                             <phase>test</phase>
+                         </execution>
+                     </executions>
+                     <configuration>
+                         <fallback>false</fallback>
+                         <buildArgs>
+                             <arg>-H:DashboardDump=BAMScanner -H:+DashboardAll</arg>
+                         </buildArgs>
+                         <agent>
+                             <enabled>true</enabled>
+                             <options>
+                                 <option>experimental-class-loader-support</option>
+                             </options>
+                         </agent>
+                     </configuration>
+                 </plugin>
+             </plugins>
+         </build>
+     </profile>
+ </profiles>
+
+
 </project>


### PR DESCRIPTION
Modifies `pom.xml` to use native-image to compile to GraalVM. More optimization can be added.